### PR TITLE
Update default base image to 7.8. Use AD count for validation rather …

### DIFF
--- a/pkg/drivers/oci/oci.go
+++ b/pkg/drivers/oci/oci.go
@@ -38,7 +38,7 @@ const (
 	defaultNodeNamePfx = "oci-node-driver-"
 	defaultSSHPort     = 22
 	defaultSSHUser     = "opc"
-	defaultImage       = "Oracle-Linux-7.7"
+	defaultImage       = "Oracle-Linux-7.8"
 	defaultDockerPort  = 2376
 	sshBitLen          = 4096
 )
@@ -324,20 +324,20 @@ func (d *Driver) Kill() error {
 func (d *Driver) PreCreateCheck() error {
 	log.Debug("oci.PreCreateCheck()")
 
-	// Check that the Oracle Linux node image exists, which will also validate the credentials.
-	log.Infof("Verifying node image availability... ")
+	// Check the number of availability domain, which will also validate the credentials.
+	log.Infof("Verifying number of availability domains... ")
 
 	oci, err := d.initOCIClient()
 	if err != nil {
 		return err
 	}
 
-	image, err := oci.getImageID(d.NodeCompartmentID, defaultImage)
+	ads, err := oci.getNumAvailabilityDomains(d.NodeCompartmentID)
 	if err != nil {
 		return err
 	}
-	if len(*image) == 0 {
-		return fmt.Errorf("could not retrieve node image ID from OCI")
+	if ads <= 0 {
+		return fmt.Errorf("could not retrieve availability domain info from OCI")
 	}
 
 	// TODO, verify VCN and subnet

--- a/pkg/drivers/oci/oci_client.go
+++ b/pkg/drivers/oci/oci_client.go
@@ -334,3 +334,15 @@ func (c *Client) getImageID(compartmentID, nodeImageName string) (*string, error
 
 	return nil, fmt.Errorf("could not retrieve image id for an image named %s", nodeImageName)
 }
+
+// getNumAvailabilityDomains gets the number of availability domains in the current region
+func (c *Client) getNumAvailabilityDomains(compartmentID string) (int, error) {
+
+	req := identity.ListAvailabilityDomainsRequest{}
+	req.CompartmentId = &compartmentID
+	ads, err := c.identityClient.ListAvailabilityDomains(context.Background(), req)
+	if err != nil {
+		return -1, err
+	}
+	return len(ads.Items), nil
+}


### PR DESCRIPTION
This MR updates default base image to 7.8. Use AD count for validation rather than trying to retrieve a base image that may or may not exist. See [this issue](https://github.com/rancher/rancher/issues/28449).